### PR TITLE
feat: drop Node.js v12 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "12 || 14 || >=16"
+    "node": "14 || 16 || >=18"
   },
   "scripts": {
     "lint": "eslint *.js test/*.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v12 is no longer supported.